### PR TITLE
TRIVIAL Update SonarQube project in catalog file [Backstage-generated]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,13 +2,15 @@ apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: public-disclosures
-  description: Repository contains required information by MITRE to reveal details of the CVE
+  description: >-
+    Repository contains required information by MITRE to reveal details of the
+    CVE
   annotations:
     backstage.io/techdocs-ref: .
-    sonarqube.org/project-key: "com.wandera.public-disclosures"
+    sonarqube.org/project-key: com.wandera.public-disclosures
   tags:
-  - security
-  - cve
+    - security
+    - cve
 spec:
   type: website
   lifecycle: production


### PR DESCRIPTION
Add SonarQube project key annotation to `catalog-info.yaml` to link project in [Backstage](https://portal.jamf.build).